### PR TITLE
Fix error stemming from bitwise regex

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -511,7 +511,7 @@
     'name': 'keyword.operator.comparison.elixir'
   }
   {
-    'match': '(\\|\\|\\||&&&|^^^|<<<|>>>|~~~)'
+    'match': '(\\|\\|\\||&&&|\\^\\^\\^|<<<|>>>|~~~)'
     'name': 'keyword.operator.bitwise.elixir'
   }
   {


### PR DESCRIPTION
This PR fixes the issues causing the converted bundle to not work properly with Atom.
