### PR TITLE
Remove extra whitespace after `def` snippet

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -1,7 +1,7 @@
 '.source.elixir':
   'def':
     'prefix': 'def'
-    'body': 'def $1 do\n\t$0\nend\n'
+    'body': 'def $1 do\n\t$0\nend'
   'defmacro':
     'prefix': 'defmacro'
     'body': 'defmacro $1 do\n\t$0\nend'


### PR DESCRIPTION
A small stylistic thing maybe, but it's been bothering me for a while in the ST package - for some reason there's an extra newline at the end of the `def` snippet - this PR removes it.
