### PR TITLE
Basic matching for function definitions

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -61,8 +61,16 @@
     'name': 'keyword.other.special-method.elixir'
   }
   {
-    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defp?|defprotocol|defimpl|defrecord|defstruct|defmacrop?|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when)\\b(?![?!])'
+    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecord|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when)\\b(?![?!])'
     'name': 'keyword.control.elixir'
+  }
+  {
+    'comment': 'functions and arguments'
+    'match': '\\b(defp?|defmacrop?)\\b\\s*([_$a-zA-Z][$\\w]*[!?]?)?'
+    'captures': {
+      '1': { 'name': 'keyword.control.elixir' }
+      '2': { 'name': 'entity.name.function.elixir' }
+    }
   }
   {
     'comment': ' as above, just doesn\'t need a \'end\' and does a logic operation'

--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -7,22 +7,22 @@
     'body': 'cond do\n\t$0\nend'
   'def':
     'prefix': 'def'
-    'body': 'def $1 do\n\t$0\nend'
+    'body': 'def ${1:function_name} do\n\t$0\nend'
+  'defp':
+    'prefix': 'defp'
+    'body': 'defp ${1:function_name} do\n\t$0\nend'
   'defmacro':
     'prefix': 'defmacro'
-    'body': 'defmacro $1 do\n\t$0\nend'
+    'body': 'defmacro ${1:macro_name} do\n\t$0\nend'
   'defmacrop':
     'prefix': 'defmacrop'
-    'body': 'defmacrop $1 do\n\t$0\nend'
+    'body': 'defmacrop ${1:macro_name} do\n\t$0\nend'
   'defmodule':
     'prefix': 'defmodule'
     'body': 'defmodule $1 do\n\t$0\nend'
   'defstruct':
     'prefix': 'defstruct'
     'body': 'defstruct [$1]'
-  'defp':
-    'prefix': 'defp'
-    'body': 'defp $1 do\n\t$0\nend'
   'do':
     'prefix': 'do'
     'body': 'do\n\t$0\nend'


### PR DESCRIPTION
Highlight function declarations properly. Later we can use this initial pattern to match arguments to functions as well.

![screenshot 2016-02-05 22 58 19](https://cloud.githubusercontent.com/assets/1642095/12864539/fea26e86-cc5b-11e5-9866-cf89db287730.png)

~~Currently this only matches `def` and `defp`. It would also make sense to match `defmacro` and `defmacrop`.~~ The match works for both function and macro definitions.

As part of this change I've also updated the function and macro snippets to add a default name. Without this the match registers the `do` as the definition which can look odd. Adding an default name conveniently solves this issue while also being more explicit.
