### PR TITLE
Match directives

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -57,7 +57,11 @@
     ]
   }
   {
-    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defp?|defprotocol|defimpl|defrecord|defstruct|defmacrop?|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|import|require|alias|use|quote|unquote|super|when)\\b(?![?!])'
+    'match': '(?<!\\.)\\b(alias|require|import|use)\\b(?![?!])'
+    'name': 'keyword.other.special-method.elixir'
+  }
+  {
+    'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defp?|defprotocol|defimpl|defrecord|defstruct|defmacrop?|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when)\\b(?![?!])'
     'name': 'keyword.control.elixir'
   }
   {


### PR DESCRIPTION
This change calls out elixir's [directives](http://elixir-lang.org/getting-started/alias-require-and-import.html) as so called `special-methods` which allows them to be themed separately from other control keywords.

![screenshot 2016-02-05 23 17 45](https://cloud.githubusercontent.com/assets/1642095/12864627/b11a31aa-cc5e-11e5-9d29-14a441668740.png)
