### PR TITLE
Match keywords as atoms.

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -460,7 +460,7 @@
         'name': 'punctuation.definition.constant.elixir'
     'comment': 'symbols'
     'match': '(?>[a-zA-Z_][\\w@]*(?>[?!])?)(:)(?!:)'
-    'name': 'constant.other.keywords.elixir'
+    'name': 'constant.other.symbol.elixir'
   }
   {
     'captures':


### PR DESCRIPTION
Since keywords are just atoms, they should be highlighted as atoms.