### PR TITLE
Add snippets for inline def and defp

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -35,6 +35,12 @@
   'if':
     'prefix': 'if'
     'body': 'if $1 do\n\t$0\nend'
+  'inline def':
+    'prefix': 'idef'
+    'body': 'def $1, do: $2'
+  'inline defp':
+    'prefix': 'idefp'
+    'body': 'defp $1, do: $2'
   'moduledoc':
     'prefix': 'mdoc'
     'body': '@moduledoc """\n$0\n"""'


### PR DESCRIPTION
As per @keathley’s suggestion, this PR uses `idef` and `idefp` as triggers for the inline snippets.