### PR TITLE
Allow TODO highlighting in '#' comments.

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -441,10 +441,11 @@
     'name': 'constant.other.symbol.elixir'
   }
   {
-    'captures':
-      '1':
+    'begin': '#'
+    'beginCaptures':
+      '0':
         'name': 'punctuation.definition.comment.elixir'
-    'match': '(?:^[ \\t]+)?(#).*$\\n?'
+    'end': '\\n'
     'name': 'comment.line.number-sign.elixir'
   }
   {
@@ -706,11 +707,15 @@
         ]
       }
       {
-        'captures':
+        'begin': '(?<=^|\\s)(#)\\s(?=[[a-zA-Z0-9,. \\t?!-][^\\x{00}-\\x{7F}]]*$)'
+        'beginCaptures':
           '1':
             'name': 'punctuation.definition.comment.elixir'
         'comment': 'We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.'
-        'match': '(?<=^|\\s)(#)\\s[[a-zA-Z0-9,. \\t?!-][^\\x{00}-\\x{7F}]]*$'
+        'end': '$\\n?'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.elixir'
         'name': 'comment.line.number-sign.elixir'
       }
     ]

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -131,3 +131,8 @@ describe "Elixir grammar", ->
     expect(tokens[1]).toEqual value: ':', scopes: ['source.elixir', 'constant.other.symbol.elixir', 'punctuation.definition.constant.elixir']
     expect(tokens[3]).toEqual value: ':', scopes: ['source.elixir', 'constant.other.symbol.elixir', 'punctuation.definition.constant.elixir']
     expect(tokens[4]).toEqual value: 'erlang', scopes: ['source.elixir', 'constant.other.symbol.elixir']
+
+  it "tokenizes comments", ->
+    {tokens} = grammar.tokenizeLine("# TODO: stuff")
+    expect(tokens[0]).toEqual value: '#', scopes: ['source.elixir', 'comment.line.number-sign.elixir', 'punctuation.definition.comment.elixir']
+    expect(tokens[1]).toEqual value: ' TODO: stuff', scopes: ['source.elixir', 'comment.line.number-sign.elixir']


### PR DESCRIPTION
This change allows highlighting of TODOs and FIXMEs, etc. with the atom/language-todo package. I've also submitted a PR to them to enable snippets in elixir source as well: atom/language-todo#43

Fixes #45 