### PR TITLE
Scope comment documentation to elixir

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -21,7 +21,7 @@
     'begin': '@(module|type)?doc (~[a-z])?"""'
     'comment': '@doc with heredocs is treated as documentation'
     'end': '\\s*"""'
-    'name': 'comment.documentation.heredoc'
+    'name': 'comment.documentation.heredoc.elixir'
     'patterns': [
       {
         'include': '#interpolated_elixir'
@@ -35,7 +35,7 @@
     'begin': '@(module|type)?doc ~[A-Z]"""'
     'comment': '@doc with heredocs is treated as documentation'
     'end': '\\s*"""'
-    'name': 'comment.documentation.heredoc'
+    'name': 'comment.documentation.heredoc.elixir'
   }
   {
     'comment': '@doc false is treated as documentation'


### PR DESCRIPTION
Currently heredocs aren't being scoped to elixir. This fix addresses that issue.