### PR TITLE
Fix regression with symbol highlighting

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -518,10 +518,6 @@
     'name': 'keyword.operator.assignment.elixir'
   }
   {
-    'match': ':'
-    'name': 'punctuation.separator.other.elixir'
-  }
-  {
     'match': '\\;'
     'name': 'punctuation.separator.statement.elixir'
   }
@@ -566,6 +562,10 @@
     'comment': 'symbols'
     'match': '(?<!:)(:)(?>[a-zA-Z_][\\w@]*(?>[?!]|=(?![>=]))?|\\<\\>|===?|!==?|<<>>|<<<|>>>|~~~|::|<\\-|\\|>|=>|~|~=|=|/|\\\\\\\\|\\*\\*?|\\.\\.?\\.?|>=?|<=?|&&?&?|\\+\\+?|\\-\\-?|\\|\\|?\\|?|\\!|@|\\%?\\{\\}|%|\\[\\]|\\^(\\^\\^)?)'
     'name': 'constant.other.symbol.elixir'
+  }
+  {
+    'match': ':'
+    'name': 'punctuation.separator.other.elixir'
   }
 ]
 'repository':

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -116,3 +116,18 @@ describe "Elixir grammar", ->
     {tokens} = grammar.tokenizeLine('[1,2,3]')
     expect(tokens[0]).toEqual value: '[', scopes: ['source.elixir', 'punctuation.section.array.elixir']
     expect(tokens[6]).toEqual value: ']', scopes: ['source.elixir', 'punctuation.section.array.elixir']
+
+  it "tokenizes symbols", ->
+    {tokens} = grammar.tokenizeLine(':erlang.system_info')
+    expect(tokens[0]).toEqual value: ':', scopes: ['source.elixir', 'constant.other.symbol.elixir', 'punctuation.definition.constant.elixir']
+    expect(tokens[1]).toEqual value: 'erlang', scopes: ['source.elixir', 'constant.other.symbol.elixir']
+
+    {tokens} = grammar.tokenizeLine('size: 0')
+    expect(tokens[0]).toEqual value: 'size', scopes: ['source.elixir', 'constant.other.symbol.elixir']
+    expect(tokens[1]).toEqual value: ':', scopes: ['source.elixir', 'constant.other.symbol.elixir', 'punctuation.definition.constant.elixir']
+
+    {tokens} = grammar.tokenizeLine('size: :erlang.system_info')
+    expect(tokens[0]).toEqual value: 'size', scopes: ['source.elixir', 'constant.other.symbol.elixir']
+    expect(tokens[1]).toEqual value: ':', scopes: ['source.elixir', 'constant.other.symbol.elixir', 'punctuation.definition.constant.elixir']
+    expect(tokens[3]).toEqual value: ':', scopes: ['source.elixir', 'constant.other.symbol.elixir', 'punctuation.definition.constant.elixir']
+    expect(tokens[4]).toEqual value: 'erlang', scopes: ['source.elixir', 'constant.other.symbol.elixir']


### PR DESCRIPTION
Doing some re-ordering of matches symbol highlighting was broken. I've fixed the ordering and also added tests for symbols.