### PR TITLE
Indent new lines that follow an equals sign.

### DIFF
--- a/settings/language-elixir.cson
+++ b/settings/language-elixir.cson
@@ -1,5 +1,5 @@
 '.source.elixir':
   'editor':
     'commentStart': '# '
-    'increaseIndentPattern': '(after|else|catch|rescue|fn|^.*(do|<\\-|\\->|\\{|\\[))\\s*$'
+    'increaseIndentPattern': '(after|else|catch|rescue|fn|^.*(do|<\\-|\\->|\\{|\\[|\\=))\\s*$'
     'decreaseIndentPattern': '^\\s*((\\}|\\])\\s*$|(after|else|catch|rescue|end)\\b)'


### PR DESCRIPTION
Any new line after an `=` will now be indented:

```elixir
some_var =
  data
  |> foo
  |> bar
```

 Closes #55 