### PR TITLE
Match atoms before control structures.

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -61,6 +61,14 @@
     'name': 'keyword.other.special-method.elixir'
   }
   {
+    'captures':
+      '1':
+        'name': 'punctuation.definition.constant.elixir'
+    'comment': 'symbols'
+    'match': '(?>[a-zA-Z_][\\w@]*(?>[?!])?)(:)(?!:)'
+    'name': 'constant.other.symbol.elixir'
+  }
+  {
     'match': '(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecord|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when)\\b(?![?!])'
     'name': 'keyword.control.elixir'
   }
@@ -431,14 +439,6 @@
       '0':
         'name': 'punctuation.definition.string.end.elixir'
     'name': 'string.quoted.other.literal.upper.elixir'
-  }
-  {
-    'captures':
-      '1':
-        'name': 'punctuation.definition.constant.elixir'
-    'comment': 'symbols'
-    'match': '(?>[a-zA-Z_][\\w@]*(?>[?!])?)(:)(?!:)'
-    'name': 'constant.other.symbol.elixir'
   }
   {
     'begin': '#'

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -132,6 +132,10 @@ describe "Elixir grammar", ->
     expect(tokens[3]).toEqual value: ':', scopes: ['source.elixir', 'constant.other.symbol.elixir', 'punctuation.definition.constant.elixir']
     expect(tokens[4]).toEqual value: 'erlang', scopes: ['source.elixir', 'constant.other.symbol.elixir']
 
+    {tokens} = grammar.tokenizeLine('case: case')
+    expect(tokens[0]).toEqual value: 'case', scopes: ['source.elixir', 'constant.other.symbol.elixir']
+    expect(tokens[1]).toEqual value: ':', scopes: ['source.elixir', 'constant.other.symbol.elixir', 'punctuation.definition.constant.elixir']
+
   it "tokenizes comments", ->
     {tokens} = grammar.tokenizeLine("# TODO: stuff")
     expect(tokens[0]).toEqual value: '#', scopes: ['source.elixir', 'comment.line.number-sign.elixir', 'punctuation.definition.comment.elixir']


### PR DESCRIPTION
`case` (and other control structures) are always being matched as keywords even when they are used as atoms or variables. I've moved the matching so that atoms are now matched before control structures which should solve the first problem. Control keywords that are being used as a variable will still highlight as keywords which I'm personally OK with because it highlights to the user that they are doing something that has the potential to cause confusion. I'm willing to discuss that point if others feel strongly.

Closes #53 