### PR TITLE
Full sigil support

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -1,4 +1,4 @@
-'comment': 'Textmate bundle for Elixir Programming Language.'
+'comment': 'Atom Syntax Parser for Elixir Programming Language.'
 'fileTypes': [
   'ex'
   'exs'
@@ -692,7 +692,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (allow for interpolation)'
-    'end': '\\}[a-z]*'
+    'end': '\\}[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -709,7 +709,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (allow for interpolation)'
-    'end': '\\][a-z]*'
+    'end': '\\][acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -726,7 +726,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (allow for interpolation)'
-    'end': '\\>[a-z]*'
+    'end': '\\>[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -743,7 +743,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (allow for interpolation)'
-    'end': '\\)[a-z]*'
+    'end': '\\)[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -760,7 +760,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (allow for interpolation)'
-    'end': '\\/[a-z]*'
+    'end': '\\/[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -776,7 +776,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (allow for interpolation)'
-    'end': "\\'[a-z]*"
+    'end': "\\'[acs]*"
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -792,7 +792,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (allow for interpolation)'
-    'end': '\\"[a-z]*'
+    'end': '\\"[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -808,7 +808,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (allow for interpolation)'
-    'end': '\\|[a-z]*'
+    'end': '\\|[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -826,14 +826,11 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (without interpolation)'
-    'end': '\\}[a-z]*'
+    'end': '\\}[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
     'name': 'string.quoted.double.literal.elixir'
-    'patterns': [
-      { 'include': '#nest_curly' }
-    ]
   }
   {
     'begin': '~W\\['
@@ -841,7 +838,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (without interpolation)'
-    'end': '\\][a-z]*'
+    'end': '\\][acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -856,7 +853,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (without interpolation)'
-    'end': '\\>[a-z]*'
+    'end': '\\>[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -871,7 +868,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (without interpolation)'
-    'end': '\\)[a-z]*'
+    'end': '\\)[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -886,7 +883,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (without interpolation)'
-    'end': '\\/[a-z]*'
+    'end': '\\/[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -898,7 +895,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (without interpolation)'
-    'end': "\\'[a-z]*"
+    'end': "\\'[acs]*"
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -910,7 +907,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (without interpolation)'
-    'end': '\\"[a-z]*'
+    'end': '\\"[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -922,7 +919,7 @@
       '0':
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (without interpolation)'
-    'end': '\\|[a-z]*'
+    'end': '\\|[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'

--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -213,6 +213,8 @@
       }
     ]
   }
+
+  # TODO: I think this is a duplicate
   {
     'begin': '~[a-z](?>""")'
     'beginCaptures':
@@ -233,6 +235,8 @@
       }
     ]
   }
+
+  # Interpolated Regex Sigils
   {
     'comment': 'Regex sigil with curlies'
     'begin': '~r\\{'
@@ -247,6 +251,21 @@
     'patterns': [
       { 'include': '#regex_sub' }
       { 'include': '#nest_curly' }
+    ]
+  }
+  {
+    'comment': 'Regex sigil with pipes'
+    'begin': '~r\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\|[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
     ]
   }
   {
@@ -312,7 +331,158 @@
     ]
   }
   {
-    'begin': '~[a-qs-z]\\{'
+    'comment': 'Regex sigil with double quotes'
+    'begin': '~r\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\"[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+  {
+    'comment': 'Regex sigil with single quotes'
+    'begin': "~r\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': "\\'[eimnosux]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+
+  # Literal Regex Sigils
+  {
+    'comment': 'Literal regex sigil with curlies'
+    'begin': '~R\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\}[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_curly' }
+    ]
+  }
+  {
+    'comment': 'Literal regex sigil with pipes'
+    'begin': '~R\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\|[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+  }
+  {
+    'comment': 'Literal regex sigil with parens'
+    'begin': '~R\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\)[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_parens'}
+    ]
+  }
+  {
+    'comment': 'Literal regex sigil with slashes'
+    'begin': '~R\\/'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\/[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+  }
+  {
+    'comment': 'Literal regex sigil with brackets'
+    'begin': '~R\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\][eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_brackets' }
+    ]
+  }
+  {
+    'comment': 'Literal regex sigil with ltgt'
+    'begin': '~R\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\>[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_ltgt'}
+    ]
+  }
+  {
+    'comment': 'Literal regex sigil with double quotes'
+    'begin': '~R\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\"[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+  {
+    'comment': 'Literal regex sigil with single quotes'
+    'begin': "~R\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': "\\'[eimnosux]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+
+
+  # User defined sigils
+  {
+    'begin': '~[a-z]\\{'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.elixir'
@@ -403,29 +573,7 @@
       }
     ]
   }
-  {
-    'begin': '~[a-z]([^\\w])'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.elixir'
-    'comment': 'sigil (allow for interpolation)'
-    'end': '\\1[a-z]*'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.interpolated.elixir'
-    'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#escaped_char'
-      }
-    ]
-  }
+
   {
     'begin': '~[A-Z](?>""")'
     'beginCaptures':
@@ -518,6 +666,7 @@
         'name': 'punctuation.definition.string.end.elixir'
     'name': 'string.quoted.other.literal.upper.elixir'
   }
+
   {
     'begin': '#'
     'beginCaptures':
@@ -579,6 +728,7 @@
     'match': '='
     'name': 'keyword.operator.assignment.elixir'
   }
+  # TODO: Do we need this?
   {
     'match': '\\;'
     'name': 'punctuation.separator.statement.elixir'

--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -234,7 +234,85 @@
     ]
   }
   {
-    'begin': '~[a-z]\\{'
+    'comment': 'Regex sigil with curlies'
+    'begin': '~r\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\}[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
+      { 'include': '#nest_curly' }
+    ]
+  }
+  {
+    'comment': 'Regex sigil with parens'
+    'begin': '~r\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\)[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
+    ]
+  }
+  {
+    'comment': 'Regex sigil with slashes'
+    'begin': '~r\\/'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\/[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
+    ]
+  }
+  {
+    'comment': 'Regex sigil with brackets'
+    'begin': '~r\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\][eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
+      { 'include': '#nest_brackets' }
+    ]
+  }
+  {
+    'comment': 'Regex sigil with ltgt'
+    'begin': '~r\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\>[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+  {
+    'begin': '~[a-qs-z]\\{'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.elixir'
@@ -647,6 +725,7 @@
       }
     ]
   'regex_sub':
+    'name': 'string.interpolated.regexp.elixir'
     'patterns': [
       {
         'include': '#interpolated_elixir'
@@ -655,21 +734,21 @@
         'include': '#escaped_char'
       }
       {
+        'name': 'string.regexp.arbitrary-repitition.elixir'
+        'match': '(\\{)\\d+(,\\d+)?(\\})'
         'captures':
           '1':
             'name': 'punctuation.definition.arbitrary-repitition.elixir'
           '3':
             'name': 'punctuation.definition.arbitrary-repitition.elixir'
-        'match': '(\\{)\\d+(,\\d+)?(\\})'
-        'name': 'string.regexp.arbitrary-repitition.elixir'
       }
       {
+        'name': 'string.regexp.character-class.elixir'
         'begin': '\\[(?:\\^?\\])?'
+        'end': '\\]'
         'captures':
           '0':
             'name': 'punctuation.definition.character-class.elixir'
-        'end': '\\]'
-        'name': 'string.regexp.character-class.elixir'
         'patterns': [
           {
             'include': '#escaped_char'

--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -214,28 +214,6 @@
     ]
   }
 
-  # TODO: I think this is a duplicate
-  {
-    'begin': '~[a-z](?>""")'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.elixir'
-    'comment': 'Double-quoted heredocs sigils'
-    'end': '^\\s*"""'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.quoted.double.heredoc.elixir'
-    'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-    ]
-  }
-
   # Interpolated Regex Sigils
   {
     'comment': 'Regex sigil with curlies'
@@ -479,7 +457,7 @@
     ]
   }
 
-  # TODO: Interpolated Charater lists sigils
+  # Interpolated Charater lists sigils
   {
     'comment': 'Character list sigil with curlies'
     'begin': '~c\\{'
@@ -609,15 +587,369 @@
     ]
   }
 
+  # Literal Charater lists sigils
+  {
+    'comment': 'Literal Character list sigil with curlies'
+    'begin': '~C\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\}[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with pipes'
+    'begin': '~C\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\|[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with parens'
+    'begin': '~C\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\)[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with curlies'
+    'begin': '~C\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\>[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with curlies'
+    'begin': '~C\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\][a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with curlies'
+    'begin': "~C\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': "\\'[a-z]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with curlies'
+    'begin': '~C\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\"[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with curlies'
+    'begin': '~C\\/'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\/[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
 
-  # TODO: Literal Charater lists sigils
-  # TODO: Interpolated String sigils
-  # TODO: Literal String sigils
-  # TODO: Interpolated word lists
-  # TODO: Literal word lists
+  # Interpolated word list sigils
+  {
+    'begin': '~w\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\}[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+      { 'include': '#nest_curly' }
+    ]
+  }
+  {
+    'begin': '~w\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\][a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+      { 'include': '#nest_brackets' }
+    ]
+  }
+  {
+    'begin': '~w\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\>[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+  {
+    'begin': '~w\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\)[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+      { 'include': '#nest_parens' }
+    ]
+  }
+  {
+    'begin': '~w\\/'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\/[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'begin': "~w\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': "\\'[a-z]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'begin': '~w\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\"[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'begin': '~w\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\|[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
 
+  # Literal word list sigils
+  {
+    'begin': '~W\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\}[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_curly' }
+    ]
+  }
+  {
+    'begin': '~W\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\][a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_brackets' }
+    ]
+  }
+  {
+    'begin': '~W\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\>[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+  {
+    'begin': '~W\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\)[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_parens' }
+    ]
+  }
+  {
+    'begin': '~W\\/'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\/[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
+  {
+    'begin': "~W\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': "\\'[a-z]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
+  {
+    'begin': '~W\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\"[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
+  {
+    'begin': '~W\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\|[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
 
-  # User defined sigils
+  # Interpolated String sigils
+  {
+    'begin': '~[a-z](?>""")'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'Double-quoted heredocs sigils'
+    'end': '^\\s*"""'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.heredoc.elixir'
+    'patterns': [
+      {
+        'include': '#interpolated_elixir'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
   {
     'begin': '~[a-z]\\{'
     'beginCaptures':
@@ -628,7 +960,7 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.interpolated.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
     'patterns': [
       {
         'include': '#interpolated_elixir'
@@ -651,17 +983,11 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.interpolated.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
     'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_brackets'
-      }
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+      { 'include': '#nest_brackets' }
     ]
   }
   {
@@ -674,17 +1000,11 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.interpolated.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
     'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_ltgt'
-      }
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+      { 'include': '#nest_ltgt' }
     ]
   }
   {
@@ -697,20 +1017,79 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.interpolated.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
     'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_parens'
-      }
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+      { 'include': '#nest_parens' }
+    ]
+  }
+  {
+    'begin': '~[a-z]\\/'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\/[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'begin': "~[a-z]\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': "\\'[a-z]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'begin': '~[a-z]\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\"[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'begin': '~[a-z]\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\|[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
     ]
   }
 
+  # Literal String sigils
   {
     'begin': '~[A-Z](?>""")'
     'beginCaptures':
@@ -721,7 +1100,7 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.quoted.other.literal.upper.elixir'
+    'name': 'string.quoted.other.literal.elixir'
   }
   {
     'begin': '~[A-Z]\\{'
@@ -733,12 +1112,7 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.quoted.other.literal.upper.elixir'
-    'patterns': [
-      {
-        'include': '#nest_curly'
-      }
-    ]
+    'name': 'string.quoted.double.literal.elixir'
   }
   {
     'begin': '~[A-Z]\\['
@@ -750,11 +1124,9 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.quoted.other.literal.upper.elixir'
+    'name': 'string.quoted.double.literal.elixir'
     'patterns': [
-      {
-        'include': '#nest_brackets'
-      }
+      { 'include': '#nest_brackets' }
     ]
   }
   {
@@ -767,11 +1139,9 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.quoted.other.literal.upper.elixir'
+    'name': 'string.quoted.double.literal.elixir'
     'patterns': [
-      {
-        'include': '#nest_ltgt'
-      }
+      { 'include': '#nest_ltgt' }
     ]
   }
   {
@@ -784,26 +1154,61 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.quoted.other.literal.upper.elixir'
+    'name': 'string.quoted.double.literal.elixir'
     'patterns': [
-      {
-        'include': '#nest_parens'
-      }
+      { 'include': '#nest_parens' }
     ]
   }
   {
-    'begin': '~[A-Z]([^\\w])'
+    'begin': '~[A-Z]\\/'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.elixir'
     'comment': 'sigil (without interpolation)'
-    'end': '\\1[a-z]*'
+    'end': '\\/[a-z]*'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.quoted.other.literal.upper.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
+  {
+    'begin': "~[A-Z]\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': "\\'[a-z]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
+  {
+    'begin': '~[A-Z]\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\"[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
+  {
+    'begin': '~[A-Z]\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\|[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
   }
 
+  # Comments
   {
     'begin': '#'
     'beginCaptures':
@@ -840,6 +1245,7 @@
     'match': '(?<!\\w)\\?(\\\\(x\\h{1,2}(?!\\h)\\b|0[0-7]{0,2}(?![0-7])\\b|[^x0MC])|(\\\\[MC]-)+\\w|[^\\s\\\\])'
     'name': 'constant.numeric.elixir'
   }
+
   {
     'match': '(\\|\\|\\||&&&|\\^\\^\\^|<<<|>>>|~~~)'
     'name': 'keyword.operator.bitwise.elixir'

--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -479,6 +479,143 @@
     ]
   }
 
+  # TODO: Interpolated Charater lists sigils
+  {
+    'comment': 'Character list sigil with curlies'
+    'begin': '~c\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\}[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with pipes'
+    'begin': '~c\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\|[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with parens'
+    'begin': '~c\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\)[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with curlies'
+    'begin': '~c\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\>[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with curlies'
+    'begin': '~c\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\][a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with curlies'
+    'begin': "~c\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': "\\'[a-z]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with curlies'
+    'begin': '~c\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\"[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with curlies'
+    'begin': '~c\\/'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\/[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+
+
+  # TODO: Literal Charater lists sigils
+  # TODO: Interpolated String sigils
+  # TODO: Literal String sigils
+  # TODO: Interpolated word lists
+  # TODO: Literal word lists
+
 
   # User defined sigils
   {

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -144,3 +144,119 @@ describe "Elixir grammar", ->
   it "tokenizes do's", ->
     {tokens} = grammar.tokenizeLine("do")
     expect(tokens[0]).toEqual value: 'do', scopes: ['source.elixir', 'keyword.control.elixir']
+
+  it "tokenizes interpolated regex sigils", ->
+    {tokens} = grammar.tokenizeLine('~r/test #{foo}/')
+    expect(tokens[0]).toEqual value: '~r/', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '/', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~r|test #{foo}|')
+    expect(tokens[0]).toEqual value: '~r|', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '|', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~r"test #{foo}"')
+    expect(tokens[0]).toEqual value: '~r"', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '"', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~r\'test #{foo}\'')
+    expect(tokens[0]).toEqual value: "~r'", scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: "'", scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~r(test #{foo})')
+    expect(tokens[0]).toEqual value: '~r(', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: ')', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~r[test #{foo}]')
+    expect(tokens[0]).toEqual value: '~r[', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: ']', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~r{test #{foo}}')
+    expect(tokens[0]).toEqual value: '~r{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~r<test #{foo}>')
+    expect(tokens[0]).toEqual value: '~r<', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '>', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
+  it "tokenizes literal regex sigils", ->
+    {tokens} = grammar.tokenizeLine('~R/test #{foo}/')
+    expect(tokens[0]).toEqual value: '~R/', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~R|test #{foo}|')
+    expect(tokens[0]).toEqual value: '~R|', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value: '|', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~R{test #{foo}}')
+    expect(tokens[0]).toEqual value: '~R{', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value : '{', scopes : ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.scope.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[4]).toEqual value : '}', scopes : ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.scope.elixir']
+    expect(tokens[5]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~R[test #{foo}]')
+    expect(tokens[0]).toEqual value: '~R[', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value: ']', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~R(test #{foo})')
+    expect(tokens[0]).toEqual value: '~R(', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value: ')', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~R<test #{foo}>')
+    expect(tokens[0]).toEqual value: '~R<', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value: '>', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~R"test #{foo}"')
+    expect(tokens[0]).toEqual value: '~R"', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value: '"', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~R\'test #{foo}\'')
+    expect(tokens[0]).toEqual value: '~R\'', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value: '\'', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+  it "does not tokenize sigils with improper delimiters", ->
+    {tokens} = grammar.tokenizeLine('~r.test.')
+    expect(tokens[0]).toEqual value: '~r', scopes: ['source.elixir']
+    expect(tokens[1]).toEqual value: '.', scopes: ['source.elixir', 'punctuation.separator.method.elixir']
+    expect(tokens[2]).toEqual value: 'test', scopes: ['source.elixir']
+    expect(tokens[3]).toEqual value: '.', scopes: ['source.elixir', 'punctuation.separator.method.elixir']

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -360,6 +360,126 @@ describe "Elixir grammar", ->
     expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
     expect(tokens[2]).toEqual value: '"', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
 
+  describe "word lists", ->
+    it "tokenizes interpolated word lists", ->
+      {tokens} = grammar.tokenizeLine('~w"#{foo} bar"')
+      expect(tokens[0]).toEqual value: '~w"', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: '"', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w[#{foo} bar]')
+      expect(tokens[0]).toEqual value: '~w[', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: ']', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w{#{foo} bar}')
+      expect(tokens[0]).toEqual value: '~w{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w\'#{foo} bar\'')
+      expect(tokens[0]).toEqual value: '~w\'', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: '\'', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w|#{foo} bar|')
+      expect(tokens[0]).toEqual value: '~w|', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: '|', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w(#{foo} bar)')
+      expect(tokens[0]).toEqual value: '~w(', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: ')', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w<#{foo} bar>')
+      expect(tokens[0]).toEqual value: '~w<', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: '>', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w/#{foo} bar/')
+      expect(tokens[0]).toEqual value: '~w/', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: '/', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+    it "tokenizes literal word lists", ->
+      {tokens} = grammar.tokenizeLine('~W"#{foo} bar"')
+      expect(tokens[0]).toEqual value: '~W"', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: '"', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~W\'#{foo} bar\'')
+      expect(tokens[0]).toEqual value: '~W\'', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: '\'', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~W[#{foo} bar]')
+      expect(tokens[0]).toEqual value: '~W[', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: ']', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~W|#{foo} bar|')
+      expect(tokens[0]).toEqual value: '~W|', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: '|', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~W{#{foo} bar}')
+      expect(tokens[0]).toEqual value: '~W{', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~W/#{foo} bar/')
+      expect(tokens[0]).toEqual value: '~W/', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: '/', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~W<#{foo} bar>')
+      expect(tokens[0]).toEqual value: '~W<', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: '>', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~W(#{foo} bar)')
+      expect(tokens[0]).toEqual value: '~W(', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: ')', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
+    it "only tokenizes the proper modifiers", ->
+      {tokens} = grammar.tokenizeLine('~w[foo]a')
+      expect(tokens[2]).toEqual value: ']a', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w[foo]c')
+      expect(tokens[2]).toEqual value: ']c', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w[foo]s')
+      expect(tokens[2]).toEqual value: ']s', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w[foo]z')
+      expect(tokens[2]).toEqual value: ']', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
   it "does not tokenize sigils with improper delimiters", ->
     {tokens} = grammar.tokenizeLine('~a.test.')
     expect(tokens[0]).toEqual value: '~a', scopes: ['source.elixir']

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -319,9 +319,50 @@ describe "Elixir grammar", ->
     expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
     expect(tokens[5]).toEqual value: '|', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
 
+  it "tokenizes Literal character lists", ->
+    {tokens} = grammar.tokenizeLine('~C(test #{foo})')
+    expect(tokens[0]).toEqual value: '~C(', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: ')', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~C[test #{foo}]')
+    expect(tokens[0]).toEqual value: '~C[', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: ']', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~C{test #{foo}')
+    expect(tokens[0]).toEqual value: '~C{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~C/test #{foo}/')
+    expect(tokens[0]).toEqual value: '~C/', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~C\'test #{foo}\'')
+    expect(tokens[0]).toEqual value: '~C\'', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '\'', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~C<test #{foo}>')
+    expect(tokens[0]).toEqual value: '~C<', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '>', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~C|test #{foo}|')
+    expect(tokens[0]).toEqual value: '~C|', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '|', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~C"test #{foo}"')
+    expect(tokens[0]).toEqual value: '~C"', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '"', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
   it "does not tokenize sigils with improper delimiters", ->
-    {tokens} = grammar.tokenizeLine('~r.test.')
-    expect(tokens[0]).toEqual value: '~r', scopes: ['source.elixir']
+    {tokens} = grammar.tokenizeLine('~a.test.')
+    expect(tokens[0]).toEqual value: '~a', scopes: ['source.elixir']
     expect(tokens[1]).toEqual value: '.', scopes: ['source.elixir', 'punctuation.separator.method.elixir']
     expect(tokens[2]).toEqual value: 'test', scopes: ['source.elixir']
     expect(tokens[3]).toEqual value: '.', scopes: ['source.elixir', 'punctuation.separator.method.elixir']

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -254,6 +254,71 @@ describe "Elixir grammar", ->
     expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
     expect(tokens[2]).toEqual value: '\'', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
 
+  it "tokenizes interpolated character lists", ->
+    {tokens} = grammar.tokenizeLine('~c(test #{foo})')
+    expect(tokens[0]).toEqual value: '~c(', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: ')', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~c/test #{foo}/')
+    expect(tokens[0]).toEqual value: '~c/', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '/', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~c[test #{foo}]')
+    expect(tokens[0]).toEqual value: '~c[', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: ']', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~c{test #{foo}}')
+    expect(tokens[0]).toEqual value: '~c{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~c<test #{foo}>')
+    expect(tokens[0]).toEqual value: '~c<', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '>', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~c"test #{foo}"')
+    expect(tokens[0]).toEqual value: '~c"', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '"', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~c\'test #{foo}\'')
+    expect(tokens[0]).toEqual value: '~c\'', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '\'', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~c|test #{foo}|')
+    expect(tokens[0]).toEqual value: '~c|', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '|', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
   it "does not tokenize sigils with improper delimiters", ->
     {tokens} = grammar.tokenizeLine('~r.test.')
     expect(tokens[0]).toEqual value: '~r', scopes: ['source.elixir']


### PR DESCRIPTION
Fully support all of elixir's default sigils `~r, ~R, ~w, ~W, ~c, ~C, ~s, ~S` and parse them as their correct types.

Closes #57, #38