### PR TITLE
Mark any unused variables as comments

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -1215,6 +1215,10 @@
     'name': 'comment.line.number-sign.elixir'
   }
   {
+    'match': '\\b_(\\w*)'
+    'name': 'comment.elixir'
+  }
+  {
     'comment': """
 			matches questionmark-letters.
 

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -12,6 +12,13 @@ describe "Elixir grammar", ->
     expect(grammar).toBeTruthy()
     expect(grammar.scopeName).toBe "source.elixir"
 
+  it "tokenizes underscore variables as comments", ->
+    {tokens} = grammar.tokenizeLine('_some_variable')
+    expect(tokens[0]).toEqual value: '_some_variable', scopes: ['source.elixir', 'comment.elixir']
+
+    {tokens} = grammar.tokenizeLine('some_variable')
+    expect(tokens[0]).toEqual value: 'some_variable', scopes: ['source.elixir']
+
   it "tokenizes bitwise operators", ->
     {tokens} = grammar.tokenizeLine('left &&& right')
     expect(tokens[1]).toEqual value: '&&&', scopes: ['source.elixir', 'keyword.operator.bitwise.elixir']


### PR DESCRIPTION
Based on #64.

Unused variables will be highlighted as a comment. Currently this is just a proof of concept to make sure that everything works correctly. There may be unforeseen side-effects from marking a variable as a comment.