### PR TITLE
Interpolate sigils with heredoc delimiters.

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -17,9 +17,11 @@
     'match': '^\\s*(defmodule)\\s+(([A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*)'
     'name': 'meta.module.elixir'
   }
+
+  # Docs - Heredoc Interpolated
   {
-    'begin': '@(module|type)?doc (~[a-z])?"""'
-    'comment': '@doc with heredocs is treated as documentation'
+    'begin': '@(module|type)?doc (~s)?"""'
+    'comment': '@doc with interpolated heredocs'
     'end': '\\s*"""'
     'name': 'comment.documentation.heredoc.elixir'
     'patterns': [
@@ -32,16 +34,52 @@
     ]
   }
   {
-    'begin': '@(module|type)?doc ~[A-Z]"""'
+    'begin': "@(module|type)?doc ~s'''"
+    'comment': '@doc with interpolated single quoted heredocs'
+    'end': "\\s*'''"
+    'name': 'comment.documentation.heredoc.elixir'
+    'patterns': [
+      {
+        'include': '#interpolated_elixir'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+
+  # Docs - Heredoc Literal
+  {
+    'begin': '@(module|type)?doc ~S"""'
     'comment': '@doc with heredocs is treated as documentation'
     'end': '\\s*"""'
     'name': 'comment.documentation.heredoc.elixir'
+    'patterns': [
+      {
+        'include': '#escaped_char'
+      }
+    ]
   }
+  {
+    'begin': "@(module|type)?doc ~S'''"
+    'comment': '@doc with heredocs is treated as documentation'
+    'end': "\\s*'''"
+    'name': 'comment.documentation.heredoc.elixir'
+    'patterns': [
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+
+  # Docs - False
   {
     'comment': '@doc false is treated as documentation'
     'match': '@(module|type)?doc false'
     'name': 'comment.documentation.false'
   }
+
+  # Docs - Non-heredoc strings
   {
     'begin': '@(module|type)?doc "'
     'comment': '@doc with string is treated as documentation'
@@ -56,10 +94,13 @@
       }
     ]
   }
+
+  # Special methods - Imports, Aliases, Requires
   {
     'match': '(?<!\\.)\\b(alias|require|import|use)\\b(?![?!])'
     'name': 'keyword.other.special-method.elixir'
   }
+
   {
     'captures':
       '1':
@@ -100,118 +141,6 @@
   {
     'match': '\\b(0[xX]\\h(?>_?\\h)*|\\d(?>_?\\d)*(\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?([eE][-+]?\\d(?>_?\\d)*)?|0[bB][01]+)\\b'
     'name': 'constant.numeric.elixir'
-  }
-  {
-    'begin': ':\''
-    'captures':
-      '0':
-        'name': 'punctuation.definition.constant.elixir'
-    'end': '\''
-    'name': 'constant.other.symbol.single-quoted.elixir'
-    'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-    ]
-  }
-  {
-    'begin': ':"'
-    'captures':
-      '0':
-        'name': 'punctuation.definition.constant.elixir'
-    'end': '"'
-    'name': 'constant.other.symbol.double-quoted.elixir'
-    'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-    ]
-  }
-  {
-    'begin': '(?>\'\'\')'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.elixir'
-    'comment': 'Single-quoted heredocs'
-    'end': '^\\s*\'\'\''
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.elixir'
-    'name': 'support.function.variable.quoted.single.heredoc.elixir'
-    'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-    ]
-  }
-  {
-    'begin': '\''
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.elixir'
-    'comment': 'single quoted string (allows for interpolation)'
-    'end': '\''
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.elixir'
-    'name': 'support.function.variable.quoted.single.elixir'
-    'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-    ]
-  }
-  {
-    'begin': '(?>""")'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.elixir'
-    'comment': 'Double-quoted heredocs'
-    'end': '^\\s*"""'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.quoted.double.heredoc.elixir'
-    'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-    ]
-  }
-  {
-    'begin': '"'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.elixir'
-    'comment': 'double quoted string (allows for interpolation)'
-    'end': '"'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.elixir'
-    'name': 'string.quoted.double.elixir'
-    'patterns': [
-      {
-        'include': '#interpolated_elixir'
-      }
-      {
-        'include': '#escaped_char'
-      }
-    ]
   }
 
   # Interpolated Regex Sigils
@@ -299,6 +228,38 @@
       '0':
         'name': 'punctuation.section.regexp.begin.elixir'
     'end': '\\>[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+  {
+    'comment': 'Regex sigil with single quoted heredocs'
+    'begin': "~r\\'\\'\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': "\\'\\'\\'[eimnosux]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.interpolated.elixir'
+    'patterns': [
+      { 'include': '#regex_sub' }
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+  {
+    'comment': 'Regex sigil with single quotes'
+    'begin': '~r\\"\\"\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\"\\"\\"[eimnosux]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.regexp.end.elixir'
@@ -427,6 +388,36 @@
     ]
   }
   {
+    'comment': 'Literal regex sigil with single quoted heredoc'
+    'begin': "~R\\'\\'\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': "\\'\\'\\'[eimnosux]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+  {
+    'comment': 'Literal regex sigil with double quoted heredoc'
+    'begin': '~R\\"\\"\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.begin.elixir'
+    'end': '\\"\\"\\"[eimnosux]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.regexp.end.elixir'
+    'name': 'string.regexp.literal.elixir'
+    'patterns': [
+      { 'include': '#nest_ltgt' }
+    ]
+  }
+  {
     'comment': 'Literal regex sigil with double quotes'
     'begin': '~R\\"'
     'beginCaptures':
@@ -540,6 +531,54 @@
   }
   {
     'comment': 'Character list sigil with curlies'
+    'begin': '~c\\/'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\/[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with single quoted heredoc'
+    'begin': "~c\\'\\'\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': "\\'\\'\\'[a-z]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with double quoted heredoc'
+    'begin': '~c\\"\\"\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\"\\"\\"[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Character list sigil with curlies'
     'begin': "~c\\'"
     'beginCaptures':
       '0':
@@ -561,22 +600,6 @@
       '0':
         'name': 'punctuation.definition.string.begin.elixir'
     'end': '\\"[a-z]*'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.elixir'
-    'name': 'support.function.variable.quoted.single.elixir'
-    'patterns': [
-      { 'include': '#interpolated_elixir' }
-      { 'include': '#escaped_char' }
-    ]
-  }
-  {
-    'comment': 'Character list sigil with curlies'
-    'begin': '~c\\/'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.elixir'
-    'end': '\\/[a-z]*'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
@@ -650,6 +673,42 @@
   }
   {
     'comment': 'Literal Character list sigil with curlies'
+    'begin': '~C\\/'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\/[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with single quoted heredoc'
+    'begin': "~C\\'\\'\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': "\\'\\'\\'[a-z]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with double quoted heredoc'
+    'begin': '~C\\"\\"\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'end': '\\"\\"\\"[a-z]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+  }
+  {
+    'comment': 'Literal Character list sigil with curlies'
     'begin': "~C\\'"
     'beginCaptures':
       '0':
@@ -667,18 +726,6 @@
       '0':
         'name': 'punctuation.definition.string.begin.elixir'
     'end': '\\"[a-z]*'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.elixir'
-    'name': 'support.function.variable.quoted.single.elixir'
-  }
-  {
-    'comment': 'Literal Character list sigil with curlies'
-    'begin': '~C\\/'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.elixir'
-    'end': '\\/[a-z]*'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
@@ -771,6 +818,54 @@
     ]
   }
   {
+    'begin': '~w\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (allow for interpolation)'
+    'end': '\\|[acs]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Interpolated word list sigil with single quoted heredoc'
+    'begin': "~w\\'\\'\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'end': "\\'\\'\\'[acs]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
+    'comment': 'Interpolated word list sigil with double quoted heredoc'
+    'begin': '~w\\"\\"\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'end': '\\"\\"\\"[acs]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.interpolated.elixir'
+    'patterns': [
+      { 'include': '#interpolated_elixir' }
+      { 'include': '#escaped_char' }
+    ]
+  }
+  {
     'begin': "~w\\'"
     'beginCaptures':
       '0':
@@ -793,22 +888,6 @@
         'name': 'punctuation.section.list.begin.elixir'
     'comment': 'sigil (allow for interpolation)'
     'end': '\\"[acs]*'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.section.list.end.elixir'
-    'name': 'string.quoted.double.interpolated.elixir'
-    'patterns': [
-      { 'include': '#interpolated_elixir' }
-      { 'include': '#escaped_char' }
-    ]
-  }
-  {
-    'begin': '~w\\|'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.section.list.begin.elixir'
-    'comment': 'sigil (allow for interpolation)'
-    'end': '\\|[acs]*'
     'endCaptures':
       '0':
         'name': 'punctuation.section.list.end.elixir'
@@ -890,6 +969,42 @@
     'name': 'string.quoted.double.literal.elixir'
   }
   {
+    'begin': '~W\\|'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'comment': 'sigil (without interpolation)'
+    'end': '\\|[acs]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
+  {
+    'comment': 'Literal word list sigil with single quoted heredoc'
+    'begin': "~W\\'\\'\\'"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'end': "\\'\\'\\'[acs]*"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
+  {
+    'comment': 'Literal word list sigil with double quoted heredoc'
+    'begin': '~W\\"\\"\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.list.begin.elixir'
+    'end': '\\"\\"\\"[acs]*'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.list.end.elixir'
+    'name': 'string.quoted.double.literal.elixir'
+  }
+  {
     'begin': "~W\\'"
     'beginCaptures':
       '0':
@@ -913,18 +1028,6 @@
         'name': 'punctuation.section.list.end.elixir'
     'name': 'string.quoted.double.literal.elixir'
   }
-  {
-    'begin': '~W\\|'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.section.list.begin.elixir'
-    'comment': 'sigil (without interpolation)'
-    'end': '\\|[acs]*'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.section.list.end.elixir'
-    'name': 'string.quoted.double.literal.elixir'
-  }
 
   # Interpolated String sigils
   {
@@ -934,6 +1037,26 @@
         'name': 'punctuation.definition.string.begin.elixir'
     'comment': 'Double-quoted heredocs sigils'
     'end': '^\\s*"""'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.heredoc.elixir'
+    'patterns': [
+      {
+        'include': '#interpolated_elixir'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+  {
+    'begin': "~[a-z](?>''')"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'Double-quoted heredocs sigils'
+    'end': "^\\s*'''"
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.elixir'
@@ -1100,6 +1223,18 @@
     'name': 'string.quoted.other.literal.elixir'
   }
   {
+    'begin': "~[A-Z](?>''')"
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'Double-quoted heredocs sigils'
+    'end': "^\\s*'''"
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.other.literal.elixir'
+  }
+  {
     'begin': '~[A-Z]\\{'
     'beginCaptures':
       '0':
@@ -1203,6 +1338,120 @@
       '0':
         'name': 'punctuation.definition.string.end.elixir'
     'name': 'string.quoted.double.literal.elixir'
+  }
+
+  # Punctuation
+  {
+    'begin': ':\''
+    'captures':
+      '0':
+        'name': 'punctuation.definition.constant.elixir'
+    'end': '\''
+    'name': 'constant.other.symbol.single-quoted.elixir'
+    'patterns': [
+      {
+        'include': '#interpolated_elixir'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+  {
+    'begin': ':"'
+    'captures':
+      '0':
+        'name': 'punctuation.definition.constant.elixir'
+    'end': '"'
+    'name': 'constant.other.symbol.double-quoted.elixir'
+    'patterns': [
+      {
+        'include': '#interpolated_elixir'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+  {
+    'begin': '(?>\'\'\')'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'Single-quoted heredocs'
+    'end': '^\\s*\'\'\''
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.heredoc.elixir'
+    'patterns': [
+      {
+        'include': '#interpolated_elixir'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+  {
+    'begin': '\''
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'single quoted string (allows for interpolation)'
+    'end': '\''
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'support.function.variable.quoted.single.elixir'
+    'patterns': [
+      {
+        'include': '#interpolated_elixir'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+  {
+    'begin': '(?>""")'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'Double-quoted heredocs'
+    'end': '^\\s*"""'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.heredoc.elixir'
+    'patterns': [
+      {
+        'include': '#interpolated_elixir'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+  {
+    'begin': '"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.elixir'
+    'comment': 'double quoted string (allows for interpolation)'
+    'end': '"'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.elixir'
+    'name': 'string.quoted.double.elixir'
+    'patterns': [
+      {
+        'include': '#interpolated_elixir'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
   }
 
   # Comments

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -217,6 +217,22 @@ describe "Elixir grammar", ->
     expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
     expect(tokens[5]).toEqual value: '>', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
 
+    {tokens} = grammar.tokenizeLine('~r"""test #{foo}"""')
+    expect(tokens[0]).toEqual value: '~r"""', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '"""', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~r\'\'\'test #{foo}\'\'\'')
+    expect(tokens[0]).toEqual value: '~r\'\'\'', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'string.regexp.interpolated.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '\'\'\'', scopes: ['source.elixir', 'string.regexp.interpolated.elixir', 'punctuation.section.regexp.end.elixir']
+
   it "tokenizes literal regex sigils", ->
     {tokens} = grammar.tokenizeLine('~R/test #{foo}/')
     expect(tokens[0]).toEqual value: '~R/', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
@@ -260,6 +276,16 @@ describe "Elixir grammar", ->
     expect(tokens[0]).toEqual value: '~R\'', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
     expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
     expect(tokens[2]).toEqual value: '\'', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~R"""test #{foo}"""')
+    expect(tokens[0]).toEqual value: '~R"""', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value: '"""', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~R\'\'\'test #{foo}\'\'\'')
+    expect(tokens[0]).toEqual value: '~R\'\'\'', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'string.regexp.literal.elixir']
+    expect(tokens[2]).toEqual value: '\'\'\'', scopes: ['source.elixir', 'string.regexp.literal.elixir', 'punctuation.section.regexp.end.elixir']
 
   it "tokenizes interpolated character lists", ->
     {tokens} = grammar.tokenizeLine('~c(test #{foo})')
@@ -326,6 +352,22 @@ describe "Elixir grammar", ->
     expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
     expect(tokens[5]).toEqual value: '|', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
 
+    {tokens} = grammar.tokenizeLine('~c"""test #{foo}"""')
+    expect(tokens[0]).toEqual value: '~c"""', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '"""', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~c\'\'\'test #{foo}\'\'\'')
+    expect(tokens[0]).toEqual value: '~c\'\'\'', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test ', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '#{', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[3]).toEqual value: 'foo', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+    expect(tokens[5]).toEqual value: '\'\'\'', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
   it "tokenizes Literal character lists", ->
     {tokens} = grammar.tokenizeLine('~C(test #{foo})')
     expect(tokens[0]).toEqual value: '~C(', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
@@ -366,6 +408,16 @@ describe "Elixir grammar", ->
     expect(tokens[0]).toEqual value: '~C"', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
     expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
     expect(tokens[2]).toEqual value: '"', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~C"""test #{foo}"""')
+    expect(tokens[0]).toEqual value: '~C"""', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '"""', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
+
+    {tokens} = grammar.tokenizeLine('~C\'\'\'test #{foo}\'\'\'')
+    expect(tokens[0]).toEqual value: '~C\'\'\'', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.begin.elixir']
+    expect(tokens[1]).toEqual value: 'test #{foo}', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir']
+    expect(tokens[2]).toEqual value: '\'\'\'', scopes: ['source.elixir', 'support.function.variable.quoted.single.elixir', 'punctuation.definition.string.end.elixir']
 
   describe "word lists", ->
     it "tokenizes interpolated word lists", ->
@@ -433,6 +485,22 @@ describe "Elixir grammar", ->
       expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
       expect(tokens[5]).toEqual value: '/', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
 
+      {tokens} = grammar.tokenizeLine('~w"""#{foo} bar"""')
+      expect(tokens[0]).toEqual value: '~w"""', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: '"""', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~w\'\'\'#{foo} bar\'\'\'')
+      expect(tokens[0]).toEqual value: '~w\'\'\'', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source']
+      expect(tokens[3]).toEqual value: '}', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'source.elixir.embedded.source', 'punctuation.section.embedded.elixir']
+      expect(tokens[4]).toEqual value: ' bar', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir']
+      expect(tokens[5]).toEqual value: '\'\'\'', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
+
     it "tokenizes literal word lists", ->
       {tokens} = grammar.tokenizeLine('~W"#{foo} bar"')
       expect(tokens[0]).toEqual value: '~W"', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
@@ -474,6 +542,16 @@ describe "Elixir grammar", ->
       expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
       expect(tokens[2]).toEqual value: ')', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
 
+      {tokens} = grammar.tokenizeLine('~W"""#{foo} bar"""')
+      expect(tokens[0]).toEqual value: '~W"""', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: '"""', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
+      {tokens} = grammar.tokenizeLine('~W\'\'\'#{foo} bar\'\'\'')
+      expect(tokens[0]).toEqual value: '~W\'\'\'', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.begin.elixir']
+      expect(tokens[1]).toEqual value: '#{foo} bar', scopes: ['source.elixir', 'string.quoted.double.literal.elixir']
+      expect(tokens[2]).toEqual value: '\'\'\'', scopes: ['source.elixir', 'string.quoted.double.literal.elixir', 'punctuation.section.list.end.elixir']
+
     it "only tokenizes the proper modifiers", ->
       {tokens} = grammar.tokenizeLine('~w[foo]a')
       expect(tokens[2]).toEqual value: ']a', scopes: ['source.elixir', 'string.quoted.double.interpolated.elixir', 'punctuation.section.list.end.elixir']
@@ -493,3 +571,47 @@ describe "Elixir grammar", ->
     expect(tokens[1]).toEqual value: '.', scopes: ['source.elixir', 'punctuation.separator.method.elixir']
     expect(tokens[2]).toEqual value: 'test', scopes: ['source.elixir']
     expect(tokens[3]).toEqual value: '.', scopes: ['source.elixir', 'punctuation.separator.method.elixir']
+
+  describe "doc attributes", ->
+    it "highlights string heredocs as comments", ->
+      {tokens} = grammar.tokenizeLine('@doc """\nTest\n"""')
+      expect(tokens[0]).toEqual value: '@doc """', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[1]).toEqual value: '\nTest', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[2]).toEqual value: '\n"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+      {tokens} = grammar.tokenizeLine('@doc ~s"""\nTest\n"""')
+      expect(tokens[0]).toEqual value: '@doc ~s"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[1]).toEqual value: '\nTest', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[2]).toEqual value: '\n"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+      {tokens} = grammar.tokenizeLine('@doc ~S"""\nTest\n"""')
+      expect(tokens[0]).toEqual value: '@doc ~S"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[1]).toEqual value: '\nTest', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[2]).toEqual value: '\n"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+      {tokens} = grammar.tokenizeLine("@doc ~S'''\nTest\n'''")
+      expect(tokens[0]).toEqual value: "@doc ~S'''", scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[1]).toEqual value: '\nTest', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+      expect(tokens[2]).toEqual value: "\n'''", scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+    it "does not highlight other sigil heredocs as comments", ->
+      {tokens} = grammar.tokenizeLine("@doc '''\nTest\n'''")
+      expect(tokens[0]).not.toEqual value: "@doc '''", scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+      {tokens} = grammar.tokenizeLine('@doc ~r"""\nTest\n"""')
+      expect(tokens[0]).not.toEqual value: '@doc ~r"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+      {tokens} = grammar.tokenizeLine('@doc ~R"""\nTest\n"""')
+      expect(tokens[0]).not.toEqual value: '@doc ~R"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+      {tokens} = grammar.tokenizeLine('@doc ~c"""\nTest\n"""')
+      expect(tokens[0]).not.toEqual value: '@doc ~c"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+      {tokens} = grammar.tokenizeLine('@doc ~C"""\nTest\n"""')
+      expect(tokens[0]).not.toEqual value: '@doc ~C"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+      {tokens} = grammar.tokenizeLine('@doc ~w"""\nTest\n"""')
+      expect(tokens[0]).not.toEqual value: '@doc ~w"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']
+
+      {tokens} = grammar.tokenizeLine('@doc ~W"""\nTest\n"""')
+      expect(tokens[0]).not.toEqual value: '@doc ~W"""', scopes: ['source.elixir', 'comment.documentation.heredoc.elixir']


### PR DESCRIPTION
Fixes the issue described in #72.

Example of issue:

<img width="548" alt="screenshot 2016-07-21 14 37 41" src="https://cloud.githubusercontent.com/assets/1642095/17034461/c709a0d4-4f50-11e6-84c8-e8325120435b.png">

I've added specific selectors for using interpolated and literal string sigils with doc attributes since we want to render them as comments. I've also added support for using heredoc (triple single quotes or triple double quotes) as delimiters for all sigils. The end result is that all sigils that use heredocs as delimiters will be highlighted correctly and all string heredocs after doc attributes will be highlighted correctly as comments.


## Todo

- [x] Write a few more tests
- [x] Verify that we only want to use string sigils after doc attributes