### PR TITLE
Add unused and wildcard variables

### DIFF
--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -1464,8 +1464,12 @@
     'name': 'comment.line.number-sign.elixir'
   }
   {
-    'match': '\\b_(\\w*)'
-    'name': 'comment.elixir'
+    'match': '\\b_([\\w]+[?!]?)'
+    'name': 'variable.other.unused.comment.elixir'
+  }
+  {
+    'match': '\\b_\\b'
+    'name': 'variable.other.wildcard.comment.elixir'
   }
   {
     'comment': """

--- a/grammars/elixir.cson
+++ b/grammars/elixir.cson
@@ -1465,11 +1465,11 @@
   }
   {
     'match': '\\b_([\\w]+[?!]?)'
-    'name': 'variable.other.unused.comment.elixir'
+    'name': 'unused.comment.elixir'
   }
   {
     'match': '\\b_\\b'
-    'name': 'variable.other.wildcard.comment.elixir'
+    'name': 'wildcard.comment.elixir'
   }
   {
     'comment': """

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -13,8 +13,17 @@ describe "Elixir grammar", ->
     expect(grammar.scopeName).toBe "source.elixir"
 
   it "tokenizes underscore variables as comments", ->
-    {tokens} = grammar.tokenizeLine('_some_variable')
-    expect(tokens[0]).toEqual value: '_some_variable', scopes: ['source.elixir', 'comment.elixir']
+    {tokens} = grammar.tokenizeLine('_some_variable?')
+    expect(tokens[0]).toEqual value: '_some_variable?', scopes: ['source.elixir', 'variable.other.unused.comment.elixir']
+
+    {tokens} = grammar.tokenizeLine('some_variable')
+    expect(tokens[0]).toEqual value: 'some_variable', scopes: ['source.elixir']
+
+  it "tokenizes underscore as wildcard variable", ->
+    {tokens} = grammar.tokenizeLine('this _ other_thing')
+    expect(tokens[0]).not.toEqual value: 'this ', scopes: ['source.elixir', 'variable.other.wildcard.comment.elixir']
+    expect(tokens[1]).toEqual value: '_', scopes: ['source.elixir', 'variable.other.wildcard.comment.elixir']
+    expect(tokens[2]).not.toEqual value: ' other_thing', scopes: ['source.elixir', 'variable.other.wildcard.comment.elixir']
 
     {tokens} = grammar.tokenizeLine('some_variable')
     expect(tokens[0]).toEqual value: 'some_variable', scopes: ['source.elixir']

--- a/spec/elixir-spec.coffee
+++ b/spec/elixir-spec.coffee
@@ -14,16 +14,16 @@ describe "Elixir grammar", ->
 
   it "tokenizes underscore variables as comments", ->
     {tokens} = grammar.tokenizeLine('_some_variable?')
-    expect(tokens[0]).toEqual value: '_some_variable?', scopes: ['source.elixir', 'variable.other.unused.comment.elixir']
+    expect(tokens[0]).toEqual value: '_some_variable?', scopes: ['source.elixir', 'unused.comment.elixir']
 
     {tokens} = grammar.tokenizeLine('some_variable')
     expect(tokens[0]).toEqual value: 'some_variable', scopes: ['source.elixir']
 
   it "tokenizes underscore as wildcard variable", ->
     {tokens} = grammar.tokenizeLine('this _ other_thing')
-    expect(tokens[0]).not.toEqual value: 'this ', scopes: ['source.elixir', 'variable.other.wildcard.comment.elixir']
-    expect(tokens[1]).toEqual value: '_', scopes: ['source.elixir', 'variable.other.wildcard.comment.elixir']
-    expect(tokens[2]).not.toEqual value: ' other_thing', scopes: ['source.elixir', 'variable.other.wildcard.comment.elixir']
+    expect(tokens[0]).not.toEqual value: 'this ', scopes: ['source.elixir', 'wildcard.comment.elixir']
+    expect(tokens[1]).toEqual value: '_', scopes: ['source.elixir', 'wildcard.comment.elixir']
+    expect(tokens[2]).not.toEqual value: ' other_thing', scopes: ['source.elixir', 'wildcard.comment.elixir']
 
     {tokens} = grammar.tokenizeLine('some_variable')
     expect(tokens[0]).toEqual value: 'some_variable', scopes: ['source.elixir']


### PR DESCRIPTION
Based on #66.

Added selectors to unused variables and the single underscore while keeping the comment selector.

It also matches unused variables ending in exclamation and question mark.