### PR TITLE
Add snippet moduletag and  line break

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -52,7 +52,7 @@
     'body': '@moduledoc """\n\f$0\n"""'
   'moduletag':
     'prefix': 'moduletag'
-    'body': '@moduletag $0'
+    'body': '@moduletag ${1::${2:your_tag}}'
   'defprotocol':
     'prefix': 'defpro'
     'body': 'defprotocol $1 do\n\t$0\nend'

--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -28,7 +28,7 @@
     'body': 'defstruct [$1]'
   'doc':
     'prefix': 'doc'
-    'body': '@doc """\n\f$0\n"""'
+    'body': '@doc """$0\n"""'
   'do':
     'prefix': 'do'
     'body': 'do\n\t$0\nend'
@@ -49,7 +49,7 @@
     'body': 'defp $1, do: $2'
   'moduledoc':
     'prefix': 'moduledoc'
-    'body': '@moduledoc """\n\f$0\n"""'
+    'body': '@moduledoc """$0\n"""'
   'moduletag':
     'prefix': 'moduletag'
     'body': '@moduletag ${1::${2:your_tag}}'
@@ -106,7 +106,7 @@
     'body': '@type ${1:type_name} :: ${2:type}'
   'typedoc':
     'prefix': 'typedoc'
-    'body': '@typedoc """\n\f$0\n"""'
+    'body': '@typedoc """$0\n"""'
   'fn':
     'prefix': 'fn'
     'body': 'fn($1) -> ${2:...} end'

--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -28,7 +28,7 @@
     'body': 'defstruct [$1]'
   'doc':
     'prefix': 'doc'
-    'body': '@doc """\n$0\n"""'
+    'body': '@doc """\n\f$0\n"""'
   'do':
     'prefix': 'do'
     'body': 'do\n\t$0\nend'
@@ -49,7 +49,7 @@
     'body': 'defp $1, do: $2'
   'moduledoc':
     'prefix': 'moduledoc'
-    'body': '@moduledoc """\n$0\n"""'
+    'body': '@moduledoc """\n\f$0\n"""'
   'moduletag':
     'prefix': 'moduletag'
     'body': '@moduletag $0'
@@ -106,7 +106,7 @@
     'body': '@type ${1:type_name} :: ${2:type}'
   'typedoc':
     'prefix': 'typedoc'
-    'body': '@typedoc """\n$0\n"""'
+    'body': '@typedoc """\n\f$0\n"""'
   'fn':
     'prefix': 'fn'
     'body': 'fn($1) -> ${2:...} end'

--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -28,7 +28,7 @@
     'body': 'defstruct [$1]'
   'doc':
     'prefix': 'doc'
-    'body': '@doc """$0\n"""'
+    'body': '@doc """\n$0\n"""'
   'do':
     'prefix': 'do'
     'body': 'do\n\t$0\nend'
@@ -49,7 +49,7 @@
     'body': 'defp $1, do: $2'
   'moduledoc':
     'prefix': 'moduledoc'
-    'body': '@moduledoc """$0\n"""'
+    'body': '@moduledoc """\n$0\n"""'
   'defprotocol':
     'prefix': 'defpro'
     'body': 'defprotocol $1 do\n\t$0\nend'
@@ -103,7 +103,7 @@
     'body': '@type ${1:type_name} :: ${2:type}'
   'typedoc':
     'prefix': 'typedoc'
-    'body': '@typedoc """$0\n"""'
+    'body': '@typedoc """\n$0\n"""'
   'fn':
     'prefix': 'fn'
     'body': 'fn($1) -> ${2:...} end'

--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -50,6 +50,9 @@
   'moduledoc':
     'prefix': 'moduledoc'
     'body': '@moduledoc """\n$0\n"""'
+  'moduletag':
+    'prefix': 'moduletag'
+    'body': '@moduletag $0'
   'defprotocol':
     'prefix': 'defpro'
     'body': 'defprotocol $1 do\n\t$0\nend'


### PR DESCRIPTION
This PR add a new snippet for `@moduletag` and `@tag` from [ExUnit.Case](https://hexdocs.pm/ex_unit/ExUnit.Case.html).

> Changed body for line break into the heredocs after openned
> ```elixir
> @moduledoc """
> |
> """
> ```
> This standard is present on official documentation and most exemples (less a `enter`)

:arrow_up_small:  Removed from this PR 1ecd2a2