### PR TITLE
Add IEx pry snippet

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -59,6 +59,9 @@
   'defoverridable':
     'prefix': 'defover'
     'body': 'defoverridable [${1:function_name}: ${2:arity}]'
+  'IEx.pry':
+    'prefix': 'pry'
+    'body': 'require IEx\nIEx.pry($0)'
   'IO.inspect':
     'prefix': 'ii'
     'body': 'IO.inspect($0)'


### PR DESCRIPTION
This PR adds [IEx.pry/1](https://hexdocs.pm/iex/IEx.html#pry/1) as a snippet. It complements `IO.inspect`and `IO.puts` snippets for debugging.

```elixir
require IEx
IEx.pry()
```

This is mainly a convenience to rapidly insert both lines. If a user doesn't need `require IEx`, they can autocomplete `IEx.pry` directly.